### PR TITLE
Remove explicit registry reference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM base/node/alpine-lts-10 as base
+ARG REGISTRY_NAME=hmcts
+FROM ${REGISTRY_NAME}.azurecr.io/hmcts/base/node/alpine-lts-10 as base
 COPY package.json yarn.lock ./
 RUN yarn install --production
 


### PR DESCRIPTION
This modification allows the acr build task to pull base images from the right registry. `hmcts` by default, or any build argument `REGISTRY_NAME` passed.