### PR TITLE
Removing flakey test

### DIFF
--- a/test/functional/healthcheck.test.js
+++ b/test/functional/healthcheck.test.js
@@ -11,20 +11,6 @@ chai.use(chaiHttp);
 //ignore self signed certs
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
-describe('GET /', function () {
-  this.timeout(httpTimeout);
-  it('should return 200 @smoke', function (done) {
-    chai
-      .request(frontendURL)
-      .get('/')
-      .end(function (err, res) {
-        expect(err).to.be.null;
-        expect(res).to.have.status(200);
-        done();
-      });
-  });
-});
-
 describe('GET /health', function () {
   this.timeout(httpTimeout);
   it('should return status OK @smoke', function (done) {


### PR DESCRIPTION
Sometimes the backend call on / times out, this is due to the ASE being flakey.
Most teams have added retries to handle this, since this is a demo app just removing the test...