### PR TITLE
DTSPO-2201 - Upgrade chart-nodejs to 2.3.9-beta - Startup probes test

### DIFF
--- a/charts/plum-frontend/Chart.yaml
+++ b/charts/plum-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 name: plum-frontend
 apiVersion: v2
 home: https://github.com/hmcts/cnp-plum-frontend
-version: 0.1.5
+version: 0.1.6
 description: HMCTS Plum frontend application (test application)
 maintainers:
   - name: HMCTS Platform Engineering Team

--- a/charts/plum-frontend/Chart.yaml
+++ b/charts/plum-frontend/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: HMCTS Platform Engineering Team
 dependencies:
   - name: nodejs
-    version: 2.3.8
+    version: 2.3.9-beta
     repository: "https://hmctspublic.azurecr.io/helm/v1/repo/"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2201


### Change description ###
Upgraded chart-nodejs to 2.3.9-beta


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
