### PR TITLE
Update Chart.yaml

### DIFF
--- a/charts/plum-frontend/Chart.yaml
+++ b/charts/plum-frontend/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: HMCTS Platform Engineering Team
 dependencies:
   - name: nodejs
-    version: 2.4.4
+    version: 2.4.5-alpha
     repository: "https://hmctspublic.azurecr.io/helm/v1/repo/"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-9277

Update to point to alpha chart testing new chart-library and disableTraefikTls in nodejs base chart.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
