### PR TITLE
DTSPO-11734 - use default branch for renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>hmcts/.github//renovate/global#0.01",
-    "github>hmcts/.github//renovate/automerge-major#0.01"
+    "github>hmcts/.github//renovate/global",
+    "github>hmcts/.github//renovate/automerge-all"
   ],
 }


### PR DESCRIPTION
### Change description ###
Reverting to using the default branch to get renovate config


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
