### PR TITLE
DTSPO-13637 Add vault reading attempt from preview to ccd in plum

### DIFF
--- a/charts/plum-frontend/values.preview.template.yaml
+++ b/charts/plum-frontend/values.preview.template.yaml
@@ -1,3 +1,8 @@
 nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  # Testing ability to access another teams AAT vault from preview with workload identity
+  keyVaults:
+    'ccd':
+      secrets:
+        - role-assignment-host

--- a/charts/plum-frontend/values.preview.template.yaml
+++ b/charts/plum-frontend/values.preview.template.yaml
@@ -1,6 +1,8 @@
 nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  useWorkloadIdentity: true
+  workloadClientID: ${WORKLOAD_IDENTITY_ID}
   # Testing ability to access another teams AAT vault from preview with workload identity
   keyVaults:
     'ccd':


### PR DESCRIPTION
Expecting this to fail


Idea is to see what role is required to make this possible in preview, and then raising a PR to add that to ccd-shared-infra repo

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
