### PR TITLE
Updating nodejs version to new release and OCI endpoint.

### DIFF
--- a/charts/crumble-frontend/Chart.yaml
+++ b/charts/crumble-frontend/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: nodejs
     version: 3.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm'
+    repository: 'oci://hmctspublic.azurecr.io/helm' 

--- a/charts/crumble-frontend/Chart.yaml
+++ b/charts/crumble-frontend/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/hmcts/cnp-plum-frontend
 version: 0.1.18
 description: HMCTS crumble frontend application (test application)
 maintainers:
-  - name: HMCTS Platform Engineering  Team
+  - name: HMCTS Platform Engineering Team
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/crumble-frontend/Chart.yaml
+++ b/charts/crumble-frontend/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/hmcts/cnp-plum-frontend
 version: 0.1.18
 description: HMCTS crumble frontend application (test application)
 maintainers:
-  - name: HMCTS Platform Engineering Team
+  - name: HMCTS Platform Engineering  Team
 dependencies:
   - name: nodejs
     version: 3.2.0

--- a/charts/crumble-frontend/Chart.yaml
+++ b/charts/crumble-frontend/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: HMCTS Platform Engineering Team
 dependencies:
   - name: nodejs
-    version: 3.1.1
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: 3.2.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'

--- a/charts/crumble-frontend/Chart.yaml
+++ b/charts/crumble-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 name: crumble-frontend
 apiVersion: v2
 home: https://github.com/hmcts/cnp-plum-frontend
-version: 0.1.17
+version: 0.1.18
 description: HMCTS crumble frontend application (test application)
 maintainers:
   - name: HMCTS Platform Engineering Team

--- a/charts/crumble-frontend/Chart.yaml
+++ b/charts/crumble-frontend/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 dependencies:
   - name: nodejs
     version: 3.2.0
-    repository: 'oci://hmctspublic.azurecr.io/helm' 
+    repository: 'oci://hmctspublic.azurecr.io/helm'

--- a/charts/plum-frontend/Chart.yaml
+++ b/charts/plum-frontend/Chart.yaml
@@ -1,7 +1,7 @@
 name: plum-frontend
 apiVersion: v2
 home: https://github.com/hmcts/cnp-plum-frontend
-version: 0.1.27
+version: 0.1.28
 description: HMCTS Plum frontend application (test application)
 maintainers:
   - name: HMCTS Platform Engineering Team

--- a/charts/plum-frontend/Chart.yaml
+++ b/charts/plum-frontend/Chart.yaml
@@ -7,5 +7,5 @@ maintainers:
   - name: HMCTS Platform Engineering Team
 dependencies:
   - name: nodejs
-    version: 3.1.1
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+    version: 3.2.0
+    repository: 'oci://hmctspublic.azurecr.io/helm'


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description
Updating chart-nodejs references to the newest release and to the new OCI endpoint.

### Testing done

Tested using this [PR](https://github.com/hmcts/cnp-plum-recipes-service/pull/1118) on the cnp-plum-recipe-service repo and pipeline.
Build successfully went green with the changes in this PR using the [pre-release](https://github.com/hmcts/chart-java/releases/tag/v5.3.0-beta) for chart java V5

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
