### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ USER hmcts
 
 COPY --chown=hmcts:hmcts . .
 ENV YARN_NODE_LINKER=pnp
-RUN yarn install
+RUN PUPPETEER_SKIP_DOWNLOAD=true yarn install
 
 # ---- Build image ----
 FROM base as build

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.4.2")
+@Library("Infrastructure@2.4.3")
 
 def type = "nodejs"
 def product = "plum"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure@2.2.0")
+@Library("Infrastructure@2.4.2")
 
 def type = "nodejs"
 def product = "plum"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -36,31 +36,31 @@ withPipeline(type, product, component) {
 
   before('functionalTest:preview') {
     sh """
-      yarn install
+      PUPPETEER_SKIP_DOWNLOAD=true yarn install
       yarn playwright install
     """
   }
 
   before('functionalTest:aat') {
     sh """
-      yarn install
+      PUPPETEER_SKIP_DOWNLOAD=true yarn install
       yarn playwright install
     """
   }
 
   before('functionalTest:perftest') {
     sh """
-      yarn install
+      PUPPETEER_SKIP_DOWNLOAD=true yarn install
       yarn playwright install
     """
   }
 
   before('smoketest:preview') {
-    sh 'yarn install'
+    sh 'PUPPETEER_SKIP_DOWNLOAD=true yarn install'
   }
 
   before('smoketest:aat') {
-    sh 'yarn install'
+    sh 'PUPPETEER_SKIP_DOWNLOAD=true yarn install'
   }
 
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "nodejs"
 def product = "plum"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -5,7 +5,7 @@ properties([
 pipelineTriggers([cron('H 07 * * 1-5')])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.2.0")
 
 def type = "nodejs"
 def product = "plum"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -5,7 +5,7 @@ properties([
 pipelineTriggers([cron('H 07 * * 1-5')])
 ])
 
-@Library("Infrastructure@2.4.2")
+@Library("Infrastructure@2.4.3")
 
 def type = "nodejs"
 def product = "plum"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -5,7 +5,7 @@ properties([
 pipelineTriggers([cron('H 07 * * 1-5')])
 ])
 
-@Library("Infrastructure@2.2.0")
+@Library("Infrastructure@2.4.2")
 
 def type = "nodejs"
 def product = "plum"

--- a/Jenkinsfile_pipeline_test
+++ b/Jenkinsfile_pipeline_test
@@ -13,7 +13,7 @@
 
 properties([
   parameters([
-    string(name: 'LIB_VERSION', defaultValue: 'master', description: 'Branch name of pipeline library to use')
+    string(name: 'LIB_VERSION', defaultValue: '2.4.3', description: 'Branch name of pipeline library to use')
   ])
 ])
 


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
